### PR TITLE
Decrease module load time

### DIFF
--- a/Rapid7Nexpose.psm1
+++ b/Rapid7Nexpose.psm1
@@ -5,7 +5,12 @@ $Private = @( Get-ChildItem -Path $PSScriptRoot\Private\*.ps1 -ErrorAction Silen
 # Dot source the files
 ForEach ($import in @($Public + $Private)) {
     Try {
-        . $import.fullname
+        # Lightweight alternative to dotsourcing a function script
+        . (
+            [ScriptBlock]::Create(
+                [System.Io.File]::ReadAllText($Import)
+            )
+        )
     }
     Catch {
         Write-Error -Message "Failed to import function $($import.fullname): $_"


### PR DESCRIPTION
When dot-sourcing script files, PowerShell attempts to validate each
file as you read it in. The alternative is to dot-source a script block
that contains the contents of the file(s).

In my testing of this module I was able to save between 7 and 9 seconds.

Get-Module | Remove-Module -Force
Measure-Command{Import-Module Rapid7Nexpose}